### PR TITLE
add docker compose ability

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
   zoo1:
     image: confluentinc/cp-zookeeper:7.3.2

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,214 @@
+version: '2.4'
+
+services:
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.3.2
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888
+
+  kafka:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+      - "9999:9999"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      zoo1:
+        condition: service_started
+
+  fast-api:
+    build: 
+      context: ./app
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: fast-api
+    command: |
+      /bin/bash -c "cd /app && \
+      mkdir -p /tmp/haadf/png && \
+      mkdir -p /tmp/haadf/dm4 && \
+      mkdir -p /tmp/haadf/scans/png && \
+      alembic upgrade head && \
+      python /app/app/cli/create_user.py --username 'distiller' --fullname 'User One' --password 'password' && \
+      /start.sh"
+    ports:
+     - "8000:80"
+    environment:
+      BACKEND_CORS_ORIGINS: '["http://localhost:8000", "http://localhost:3000"]'
+      POSTGRES_SERVER: postgres
+      POSTGRES_USER: postgres 
+      POSTGRES_PASSWORD: mysecretpassword 
+      POSTGRES_DB: postgres
+      SERVER_HOST: http://fast-api:80/api/v1
+      KAFKA_BOOTSTRAP_SERVERS: '["kafka:19092"]'
+      MACHINES: '[{"name": "perlmutter", "account": "m3795", "qos": "realtime", "nodes": 2, "ntasks": 2, "constraint": "cpu", "cpus_per_task": 128, "ntasks_per_node": 2, "bbcp_dest_dir": "/tmp/ncem"}]'
+      NCEMHUB_PATH: "/tmp"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      postgres:
+        condition: service_started
+    volumes:
+      - ./app/alembic:/app/alembic
+    restart: on-failure
+
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_SERVER: postgres
+      POSTGRES_USER: postgres 
+      POSTGRES_PASSWORD: mysecretpassword 
+      POSTGRES_DB: postgres
+    platform: linux/amd64
+    container_name: postgres
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+    restart: on-failure
+
+  job-worker:
+    build:
+      context: ./faust
+      dockerfile: Dockerfile.job_worker
+    platform: linux/amd64
+    container_name: job-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure
+
+  notebook-worker:
+    build: 
+      context: ./faust
+      dockerfile: Dockerfile.notebook_worker
+    platform: linux/amd64
+    container_name: notebook-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure
+
+  cron-worker:
+    build: 
+      context: ./faust
+      dockerfile: Dockerfile.worker
+      args: 
+        - WORKER=cron
+    platform: linux/amd64
+    container_name: cron-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure
+
+  custodian-worker:
+    build: 
+      context: ./faust
+      dockerfile: Dockerfile.worker
+      args: 
+        - WORKER=custodian
+    platform: linux/amd64
+    container_name: custodian-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure
+
+  scan-file-worker:
+    build: 
+      context: ./faust
+      dockerfile: Dockerfile.worker
+      args: 
+        - WORKER=scan_file
+    platform: linux/amd64
+    container_name: scan-file-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure
+
+  scan-worker:
+    build: 
+      context: ./faust
+      dockerfile: Dockerfile.worker
+      args: 
+        - WORKER=scan
+    platform: linux/amd64
+    container_name: scan-worker
+    environment:
+      KAFKA_BROKER: kafka:19092
+      KAFKA_URL: "kafka://kafka:19092"
+      API_URL: "http://fast-api:80/api/v1"
+    depends_on:
+      kafka:
+        condition: service_started
+      zoo1:
+        condition: service_started
+      fast-api:
+        condition: service_started
+    restart: on-failure

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       zoo1:
         condition: service_started
     restart: on-failure
+    healthcheck:
+      test: kafka-topics --bootstrap-server kafka:9092 --list
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   fast-api:
     build: 
@@ -65,11 +70,9 @@ services:
       NCEMHUB_PATH: "/tmp"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
+        condition: service_healthy
       postgres:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - ./app/alembic:/app/alembic
     restart: on-failure
@@ -83,12 +86,12 @@ services:
       POSTGRES_DB: postgres
     platform: linux/amd64
     container_name: postgres
-    depends_on:
-      kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
     restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 
   job-worker:
     build:
@@ -102,11 +105,7 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   notebook-worker:
@@ -121,11 +120,7 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   cron-worker:
@@ -142,11 +137,7 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   custodian-worker:
@@ -163,11 +154,7 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   scan-file-worker:
@@ -184,11 +171,7 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
 
   scan-worker:
@@ -205,9 +188,5 @@ services:
       API_URL: "http://fast-api:80/api/v1"
     depends_on:
       kafka:
-        condition: service_started
-      zoo1:
-        condition: service_started
-      fast-api:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     depends_on:
       zoo1:
         condition: service_started
+    restart: on-failure
 
   fast-api:
     build: 

--- a/frontend/distiller/README.md
+++ b/frontend/distiller/README.md
@@ -1,9 +1,17 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app), using the [Redux](https://redux.js.org/) and [Redux Toolkit](https://redux-toolkit.js.org/) template.
 
 ## Setting the server API URL
+
 ```bash
-export VITE_API_URL=http://...
+# Don't use trailing "/"
+export VITE_API_URL="http://localhost:8000/api/v1"
 ```
+
+## Installing
+
+In the project directory, first run:
+
+### `yarn install`
 
 ## Available Scripts
 
@@ -13,6 +21,8 @@ In the project directory, you can run:
 
 Runs the app in the development mode.<br />
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+You can sign in to distiller using: `username=distiller, password=password` for local development after `docker compose up -d`.
 
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.


### PR DESCRIPTION
This PR adds a docker compose.

Running the following commands in order will create the stack:

```bash
docker compose up --build --force-recreate -d
```

This creates a "distiller" user with the password "password". I also had to include try/except in create_user.py to avoid container failing if postgres already has "distiller" as user.

You should be able to test this by running from `distiller/frontend/distiller`
```bash
export REACT_APP_API_URL=http://localhost:8000/api/v1
yarn start
```

Right now the database doesn't start with anything in it except for the normal startup ones (-20, -30, -40...). It would be useful to have at least one fake scan so that `scan_worker` wouldn't continuously restart. That could be a separate PR.
