### PR TITLE
Improve frontend dockerfile cache

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+distiller/build
+distiller/node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,15 @@
 FROM node:18.6.0 as build
-COPY ./distiller /distiller
+
+WORKDIR /distiller
+
+COPY ./distiller/package.json ./
+COPY ./distiller/package-lock.json ./
+RUN yarn
+
+COPY ./distiller .
 ARG REACT_APP_API_URL
 ARG REACT_APP_SENTRY_DSN_URL
-RUN cd /distiller && yarn && REACT_APP_API_URL=$REACT_APP_API_URL REACT_APP_SENTRY_DSN_URL=$REACT_APP_SENTRY_DSN_URL yarn build
+RUN REACT_APP_API_URL=$REACT_APP_API_URL REACT_APP_SENTRY_DSN_URL=$REACT_APP_SENTRY_DSN_URL yarn build
 
 FROM nginx
 COPY --from=build /distiller/build/ /usr/share/nginx/html


### PR DESCRIPTION
Currently, the `yarn` is run on every image build, and dependencies can take a while to build.  This PR changes that, so that the `yarn` step is cached.