### PR TITLE
pin pydantic to v1.10.10 everywhere

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           # The requirements from requirements.base.txt minus rocksdb which
           # is install as a debian package above
-          pip install faust-streaming pydantic[dotenv]==v1.10.10 numpy
+          pip install faust-streaming pydantic numpy
           pip install -r requirements.job.txt -r requirements.dev.txt
       - name: Set PYTHONPATH
         run: |

--- a/backend/app/app/api/api_v1/endpoints/jobs.py
+++ b/backend/app/app/api/api_v1/endpoints/jobs.py
@@ -27,8 +27,8 @@ async def create_job(job: schemas.JobCreate, db: Session = Depends(get_db)):
 
     job = crud.create_job(db=db, job=job)
 
-    scan = schemas.Scan.from_orm(scan)
-    job = schemas.Job.from_orm(job)
+    scan = schemas.Scan.model_validate(scan)
+    job = schemas.Job.model_validate(job)
 
     await send_submit_job_event_to_kafka(SubmitJobEvent(scan=scan, job=job))
 

--- a/backend/app/app/crud/job.py
+++ b/backend/app/app/crud/job.py
@@ -32,7 +32,7 @@ def get_jobs(
 
 
 def create_job(db: Session, job: schemas.JobCreate):
-    db_job = models.Job(**job.dict())
+    db_job = models.Job(**job.model_dump())
     db.add(db_job)
     db.commit()
     db.refresh(db_job)

--- a/backend/app/app/crud/scan.py
+++ b/backend/app/app/crud/scan.py
@@ -147,10 +147,10 @@ def create_scan(
         scan.microscope_id = microscope_ids[0]
 
     # Note: We have to pass metadata as metadata_ as metadata is reserved!
-    db_scan = models.Scan(**scan.dict(), image_path=image_path, metadata_=scan.metadata)
+    db_scan = models.Scan(**scan.model_dump(), image_path=image_path, metadata_=scan.metadata)
     db.add(db_scan)
     for l in locations:
-        l = models.Location(**l.dict())
+        l = models.Location(**l.model_dump())
         db_scan.locations.append(l)
         db.add(l)
     db.commit()
@@ -192,7 +192,7 @@ def update_scan(
                 is not None
             )
             if not exists:
-                l = models.Location(**l.dict(), scan_id=id)
+                l = models.Location(**l.model_dump(), scan_id=id)
                 db.add(l)
                 locations_updated = True
 

--- a/backend/app/app/main.py
+++ b/backend/app/app/main.py
@@ -34,7 +34,7 @@ async def shutdown_event():
 if settings.BACKEND_CORS_ORIGINS:
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+        allow_origins=[str(origin).rstrip("/") for origin in settings.BACKEND_CORS_ORIGINS],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/backend/app/app/schemas/file.py
+++ b/backend/app/app/schemas/file.py
@@ -36,7 +36,7 @@ class File(BaseModel):
 
 
 class SyncEvent(BaseModel):
-    microscope_id: Optional[int]
+    microscope_id: Optional[int] = None
     files: List[File]
 
 

--- a/backend/app/app/schemas/job.py
+++ b/backend/app/app/schemas/job.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from enum import Enum
 from typing import Dict, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 
 class JobType(str, Enum):
@@ -51,14 +51,12 @@ class Job(BaseModel):
     job_type: JobType
     scan_id: int
     machine: str
-    slurm_id: Optional[int]
+    slurm_id: Optional[int] = None
     state: JobState = JobState.INITIALIZING
     params: Dict[str, Union[str, int, float]]
-    output: Optional[str]
-    elapsed: Optional[timedelta]
-
-    class Config:
-        orm_mode = True
+    output: Optional[str] = None
+    elapsed: Optional[timedelta] = None
+    model_config = ConfigDict(from_attributes=True)
 
 
 class JobCreate(BaseModel):
@@ -69,7 +67,7 @@ class JobCreate(BaseModel):
 
 
 class JobUpdate(BaseModel):
-    slurm_id: Optional[int]
-    state: Optional[JobState]
-    output: Optional[str]
-    elapsed: Optional[timedelta]
+    slurm_id: Optional[int] = None
+    state: Optional[JobState] = None
+    output: Optional[str] = None
+    elapsed: Optional[timedelta] = None

--- a/backend/app/app/schemas/machine.py
+++ b/backend/app/app/schemas/machine.py
@@ -7,11 +7,11 @@ class Machine(BaseModel):
     name: str
     account: str
     qos: str
-    qos_filter: Optional[str]
+    qos_filter: Optional[str] = None
     nodes: int
     constraint: str
     ntasks: int
-    ntasks_per_node: Optional[int]
+    ntasks_per_node: Optional[int] = None
     cpus_per_task: int
     bbcp_dest_dir: str
-    reservation: Optional[str]
+    reservation: Optional[str] = None

--- a/backend/app/app/schemas/microscope.py
+++ b/backend/app/app/schemas/microscope.py
@@ -1,17 +1,15 @@
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 
 class Microscope(BaseModel):
     id: int
     name: str
-    config: Optional[Dict[str, Any]]
-    state: Optional[Dict[str, Any]]
-
-    class Config:
-        orm_mode = True
+    config: Optional[Dict[str, Any]] = None
+    state: Optional[Dict[str, Any]] = None
+    model_config = ConfigDict(from_attributes=True)
 
 
 class MicroscopeUpdate(BaseModel):

--- a/backend/app/app/schemas/scan.py
+++ b/backend/app/app/schemas/scan.py
@@ -117,12 +117,12 @@ class ScanCreatedEvent(ScanEvent):
     microscope_id: int
     scan_id: Optional[int] = None
     created: datetime
-    event_type = ScanEventType.CREATED
+    event_type: ScanEventType = ScanEventType.CREATED
     image_path: Optional[str] = None
 
 
 class ScanUpdateEvent(ScanEvent):
-    event_type = ScanEventType.UPDATED
+    event_type: ScanEventType = ScanEventType.UPDATED
     jobs: Optional[List[Job]] = None
     image_path: Optional[str] = None
     notes: Optional[str] = None

--- a/backend/app/app/schemas/scan.py
+++ b/backend/app/app/schemas/scan.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import ConfigDict, BaseModel, Field, validator
 
 from app.schemas.job import Job
 
@@ -12,9 +12,7 @@ class Location(BaseModel):
     id: int
     host: str
     path: str
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class LocationCreate(BaseModel):
@@ -45,21 +43,19 @@ def metadata_infinity(metadata):
 
 class Scan(BaseModel):
     id: int
-    scan_id: Optional[int]
+    scan_id: Optional[int] = None
     progress: int
     created: datetime
     locations: List[Location]
-    image_path: Optional[str]
-    notes: Optional[str]
+    image_path: Optional[str] = None
+    notes: Optional[str] = None
     jobs: List[Job]
-    metadata: Optional[Dict[str, Any]] = Field(alias="metadata_")
+    metadata: Optional[Dict[str, Any]] = Field(None, alias="metadata_")
     microscope_id: int
-    uuid: Optional[str]
+    uuid: Optional[str] = None
 
     _metadata_infinity = validator("metadata", allow_reuse=True)(metadata_infinity)
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Scan4DCreate(BaseModel):
@@ -67,8 +63,8 @@ class Scan4DCreate(BaseModel):
     created: datetime
     uuid: str
     locations: List[LocationCreate]
-    metadata: Optional[Dict[str, Any]]
-    microscope_id: Optional[int]
+    metadata: Optional[Dict[str, Any]] = None
+    microscope_id: Optional[int] = None
 
     _metadata_infinity = validator("metadata", allow_reuse=True)(metadata_infinity)
 
@@ -83,7 +79,7 @@ class ScanFromFile(BaseModel):
     sha: str
     created: datetime
     locations: List[LocationCreate]
-    metadata: Optional[Dict[str, Any]]
+    metadata: Optional[Dict[str, Any]] = None
     microscope_id: int
 
     _metadata_infinity = validator("metadata", allow_reuse=True)(metadata_infinity)
@@ -92,9 +88,9 @@ class ScanFromFile(BaseModel):
 class ScanUpdate(BaseModel):
     progress: Optional[int] = None
     locations: Optional[List[LocationCreate]] = None
-    notes: Optional[str]
-    image_path: Optional[str]
-    metadata: Optional[Dict[str, Any]]
+    notes: Optional[str] = None
+    image_path: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
 
     _metadata_infinity = validator("metadata", allow_reuse=True)(metadata_infinity)
 
@@ -112,14 +108,14 @@ class ScanEventType(str, Enum):
 
 class ScanEvent(BaseModel):
     id: int
-    progress: Optional[int]
-    locations: Optional[List[Location]]
+    progress: Optional[int] = None
+    locations: Optional[List[Location]] = None
     event_type: ScanEventType
 
 
 class ScanCreatedEvent(ScanEvent):
     microscope_id: int
-    scan_id: Optional[int]
+    scan_id: Optional[int] = None
     created: datetime
     event_type = ScanEventType.CREATED
     image_path: Optional[str] = None
@@ -127,6 +123,6 @@ class ScanCreatedEvent(ScanEvent):
 
 class ScanUpdateEvent(ScanEvent):
     event_type = ScanEventType.UPDATED
-    jobs: Optional[List[Job]]
-    image_path: Optional[str]
-    notes: Optional[str]
+    jobs: Optional[List[Job]] = None
+    image_path: Optional[str] = None
+    notes: Optional[str] = None

--- a/backend/app/app/schemas/user.py
+++ b/backend/app/app/schemas/user.py
@@ -1,15 +1,13 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 
 class User(BaseModel):
     username: str
     full_name: Optional[str] = None
     hashed_password: str
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserCreate(BaseModel):

--- a/backend/app/requirements.txt
+++ b/backend/app/requirements.txt
@@ -4,7 +4,9 @@ python-multipart
 python-jose[cryptography]
 passlib[bcrypt]
 sqlalchemy
-pydantic[dotenv]
+pydantic~=2.0
+pydantic-settings
+pyyaml==5.3.1
 psycopg2
 aiokafka
 alembic

--- a/backend/faust/config.py
+++ b/backend/faust/config.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
-from pydantic import AnyHttpUrl, BaseSettings
+from pydantic import AnyHttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -39,10 +40,7 @@ class Settings(BaseSettings):
     CUSTODIAN_USER: str
     CUSTODIAN_PRIVATE_KEY: str
     CUSTODIAN_VALID_HOSTS: List[str] = []
-
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
 
 
 settings = Settings()

--- a/backend/faust/config.py
+++ b/backend/faust/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     JOB_QOS: str
     JOB_QOS_FILTER: str
     JOB_BBCP_EXECUTABLE_PATH: str
-    JOB_MACHINE_OVERRIDES_PATH: Optional[str]
+    JOB_MACHINE_OVERRIDES_PATH: Optional[str] = None
 
     IMAGE_UPLOAD_DIR: str
     HAADF_IMAGE_UPLOAD_DIR_EXPIRATION_HOURS: int
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     CUSTODIAN_USER: str
     CUSTODIAN_PRIVATE_KEY: str
     CUSTODIAN_VALID_HOSTS: List[str] = []
-    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env", extra="allow")
 
 
 settings = Settings()

--- a/backend/faust/job_worker.py
+++ b/backend/faust/job_worker.py
@@ -297,7 +297,7 @@ async def process_submit_job_event(
     bbcp_dest_dir = str(Path(machine.bbcp_dest_dir) / str(event.job.id))
 
     # Not sure why by created comes in as a str, so convert to datetime
-    created_datetime = datetime.fromisoformat(event.scan.created)
+    created_datetime = datetime.fromisoformat(str(event.scan.created).rstrip("Z"))
     date_dir = created_datetime.astimezone().strftime(DATE_DIR_FORMAT)
 
     base_dir = None

--- a/backend/faust/requirements.base.txt
+++ b/backend/faust/requirements.base.txt
@@ -1,4 +1,5 @@
 faust-streaming
-python-rocksdb
-pydantic[dotenv]==v1.10.10
+python-rocksdb==0.7.0
+pydantic~=2.0
+pydantic-settings
 numpy

--- a/backend/faust/requirements.cron.txt
+++ b/backend/faust/requirements.cron.txt
@@ -1,2 +1,4 @@
 pytz
 aiopath
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.custodian.txt
+++ b/backend/faust/requirements.custodian.txt
@@ -1,1 +1,3 @@
 fabric==2.7.1
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.dev.txt
+++ b/backend/faust/requirements.dev.txt
@@ -6,3 +6,5 @@ aiopath
 pytest
 pytest-mock
 pytest-asyncio
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.haadf.txt
+++ b/backend/faust/requirements.haadf.txt
@@ -3,3 +3,5 @@ matplotlib
 tenacity
 aiohttp
 aiopath
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.job.txt
+++ b/backend/faust/requirements.job.txt
@@ -6,3 +6,5 @@ aiopath
 python-dotenv
 numpy
 authlib
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.notebook.txt
+++ b/backend/faust/requirements.notebook.txt
@@ -3,3 +3,5 @@ tenacity
 aiohttp
 aiopath
 python-dotenv
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.scan.txt
+++ b/backend/faust/requirements.scan.txt
@@ -3,3 +3,5 @@ aiohttp
 pytz
 numpy
 aiopath
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/requirements.scan_file.txt
+++ b/backend/faust/requirements.scan_file.txt
@@ -3,3 +3,5 @@ matplotlib
 tenacity
 aiohttp
 aiopath
+pydantic~=2.0
+pydantic-settings

--- a/backend/faust/scan_worker.py
+++ b/backend/faust/scan_worker.py
@@ -164,7 +164,7 @@ async def process_status_file(
     if event.content is None:
         raise Exception("Status file not included!")
 
-    status_file = ScanStatusFile.parse_raw(event.content)
+    status_file = ScanStatusFile.model_validate_json(event.content)
     scan_id = status_file.last_scan_number
     new_scan = scan_id not in scan_id_to_distiller_id
     primary_status_file = (
@@ -337,7 +337,7 @@ async def watch_for_event(file_events):
                 raise Exception("Status file not included!")
 
             try:
-                status_file = ScanStatusFile.parse_raw(event.content)
+                status_file = ScanStatusFile.model_validate_json(event.content)
             except ValidationError:
                 logger.warning(f"Skipping {path}, with validation error.")
                 continue
@@ -373,7 +373,7 @@ async def process_sync_event(session: aiohttp.ClientSession, event: SyncEvent) -
         )
 
         try:
-            status = ScanStatusFile.parse_raw(f.content)
+            status = ScanStatusFile.model_validate_json(f.content)
         except ValidationError:
             logger.warning(f"Skipping {path}, with validation error.")
             continue

--- a/backend/faust/schemas.py
+++ b/backend/faust/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from dateutil.parser import parse
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, ConfigDict, BaseModel, Field
 
 from json_utils import numpy_dumps
 
@@ -18,21 +18,22 @@ class ScanStatusFile(BaseModel):
     progress: float
     uuid: str = Field(None, alias="UUID")
 
-    @validator("time", pre=True)
+    @field_validator("time", mode="before")
+    @classmethod
     def time_validate(cls, v):
         return parse(v)
 
 
 class Scan(BaseModel):
     id: int
-    scan_id: Optional[int]
+    scan_id: Optional[int] = None
     progress: int
     locations: List[Location]
     created: datetime
     image_path: Optional[str] = None
-    metadata: Optional[Dict[str, Any]]
+    metadata: Optional[Dict[str, Any]] = None
     microscope_id: int
-    uuid: Optional[str]
+    uuid: Optional[str] = None
 
 
 class ScanCreate(BaseModel):
@@ -40,32 +41,32 @@ class ScanCreate(BaseModel):
     uuid: str
     created: str
     locations: List[Location]
-    metadata: Optional[Dict[str, Any]]
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class ScanUpdate(BaseModel):
     id: int
-    progress: Optional[int]
-    locations: Optional[List[Location]]
-    metadata: Optional[Dict[str, Any]]
-
-    class Config:
-        json_dumps = numpy_dumps
+    progress: Optional[int] = None
+    locations: Optional[List[Location]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    # TODO[pydantic]: The following keys were removed: `json_dumps`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(json_dumps=numpy_dumps)
 
 
 class JobUpdate(BaseModel):
     id: int
-    slurm_id: Optional[int]
-    state: Optional[str]
-    output: Optional[str]
-    elapsed: Optional[timedelta]
+    slurm_id: Optional[int] = None
+    state: Optional[str] = None
+    output: Optional[str] = None
+    elapsed: Optional[timedelta] = None
 
 
 class Job(BaseModel):
     id: int
     job_type: str
     scan_id: int
-    slurm_id: Optional[int]
+    slurm_id: Optional[int] = None
     state: str
     machine: str
 
@@ -82,18 +83,18 @@ class Machine(BaseModel):
     name: str
     account: str
     qos: str
-    qos_filter: Optional[str]
+    qos_filter: Optional[str] = None
     nodes: int
     constraint: str
     ntasks: int
-    ntasks_per_node: Optional[int]
+    ntasks_per_node: Optional[int] = None
     cpus_per_task: int
-    cpu_bind: Optional[str]
+    cpu_bind: Optional[str] = None
     bbcp_dest_dir: str
-    reservation: Optional[str]
+    reservation: Optional[str] = None
 
 
 class Microscope(BaseModel):
     id: int
     name: str
-    config: Optional[Dict[str, Any]]
+    config: Optional[Dict[str, Any]] = None

--- a/cli/custodian/distiller/config.py
+++ b/cli/custodian/distiller/config.py
@@ -1,15 +1,11 @@
 from typing import List
-
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     SCAN_DIRECTORIES: List[str]
     LOG_FILE_PATH: str = None
-
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
 
 
 settings = Settings()

--- a/cli/custodian/requirements.txt
+++ b/cli/custodian/requirements.txt
@@ -1,2 +1,3 @@
 coloredlogs
-pydantic[dotenv]
+pydantic~=2.0
+pydantic-settings

--- a/cli/watch/distiller/config.py
+++ b/cli/watch/distiller/config.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from pydantic import AnyHttpUrl, BaseSettings
+from pydantic import AnyHttpUrl
 from schemas import WatchMode
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -16,10 +17,7 @@ class Settings(BaseSettings):
     MICROSCOPE: str
     POLL: bool = False
     RECURSIVE: bool = False
-
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
 
 
 settings = Settings()

--- a/cli/watch/distiller/schemas.py
+++ b/cli/watch/distiller/schemas.py
@@ -45,7 +45,7 @@ class File(BaseModel):
 
 
 class SyncEvent(BaseModel):
-    microscope_id: Optional[int]
+    microscope_id: Optional[int] = None
     files: List[File]
 
 class Location(BaseModel):
@@ -60,12 +60,12 @@ class ScanFromFileMetadata(BaseModel):
 class Microscope(BaseModel):
     id: int
     name: str
-    config: Optional[Dict[str, Any]]
-    state: Optional[Dict[str, Any]]
+    config: Optional[Dict[str, Any]] = None
+    state: Optional[Dict[str, Any]] = None
 
 class Scan(BaseModel):
     id: int
-    scan_id: Optional[int]
+    scan_id: Optional[int] = None
     locations: List[Location]
     created: datetime
     image_path: Optional[str] = None

--- a/cli/watch/requirements.txt
+++ b/cli/watch/requirements.txt
@@ -3,7 +3,8 @@ aiohttp
 watchdog
 coloredlogs
 cachetools
-pydantic[dotenv]
+pydantic~=2.0
+pydantic-settings
 tenacity
 h5py
 ncempy


### PR DESCRIPTION
Recent version of pydantic takes BaseSettings to a different package:

https://docs.pydantic.dev/latest/concepts/pydantic_settings/

This was an issue for me when I installed pydantic recently for the watcher cli. It will probably cause issues with other sections of the code, so I pinned it everywhere after searching the repo for `pydantic[dotenv]`. It was already pinned in the microservices base image.