### PR TITLE
Websocket closed causes exception to be logged

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/notifications.py
+++ b/backend/app/app/api/api_v1/endpoints/notifications.py
@@ -93,7 +93,7 @@ class WebsocketConsumer(WebSocketEndpoint):
                 if microscope_id is None or microscope_id == self.microscope_id:
                     await self.websocket.send_json(event)
         except asyncio.CancelledError:
-            logger.info("websocket connection closed, relay_events task cancelled")
+            logger.info("Websocket connection closed, relay_events task cancelled")
         except Exception as e:
             logger.exception("Exception relaying kafka message: %s", str(e))
         finally:

--- a/backend/app/app/api/api_v1/endpoints/notifications.py
+++ b/backend/app/app/api/api_v1/endpoints/notifications.py
@@ -92,7 +92,9 @@ class WebsocketConsumer(WebSocketEndpoint):
                 # Only send the message for the associated microscope
                 if microscope_id is None or microscope_id == self.microscope_id:
                     await self.websocket.send_json(event)
-        except:
-            logger.exception("Exception relaying kafka message.")
+        except asyncio.CancelledError:
+            logger.info("websocket connection closed, relay_events task cancelled")
+        except Exception as e:
+            logger.exception("Exception relaying kafka message: %s", str(e))
         finally:
             await self.consumer.stop()


### PR DESCRIPTION
Every time a websocket is closed, an exception is raised in fastapi:


```python
[2023-11-16 21:40:35 -0800] [9] [INFO] connection closed
2023-11-16 21:40:35,681 - distiller - ERROR - Exception relaying kafka message.
Traceback (most recent call last):
  File "/app/app/api/api_v1/endpoints/notifications.py", line 77, in relay_events
    async for msg in self.consumer:
  File "/usr/local/lib/python3.8/site-packages/aiokafka/consumer/consumer.py", line 1264, in __anext__
    return (await self.getone())
  File "/usr/local/lib/python3.8/site-packages/aiokafka/consumer/consumer.py", line 1150, in getone
    msg = await self._fetcher.next_record(partitions)
  File "/usr/local/lib/python3.8/site-packages/aiokafka/consumer/fetcher.py", line 1041, in next_record
    await waiter
asyncio.exceptions.CancelledError

```

This is not really an error. It doesn't really matter because we have the finally block to stop the consumer, but it is aggressive to look at when searching through logs (it shows up very frequently). Not sure if there is another scenario where `CancelledError` could arise.

Also added error string to unexpected error block.