### PR TITLE
Replace nav buttons with breadcrumbs

### DIFF
--- a/frontend/distiller/src/components/session-card.tsx
+++ b/frontend/distiller/src/components/session-card.tsx
@@ -151,9 +151,11 @@ const SessionCard = React.memo(
                 alignItems: 'center',
               }}
             >
-              <Typography variant="h5" component="div">
-                {job.id}
-              </Typography>
+              {compactMode && (
+                <Typography variant="h5" component="div">
+                  {job.id}
+                </Typography>
+              )}
               <Typography variant="h5" component="div">
                 {isJobRunning &&
                   humanizeDuration(job.elapsed ? job.elapsed * 1000 : 0)}

--- a/frontend/distiller/src/pages/scan.tsx
+++ b/frontend/distiller/src/pages/scan.tsx
@@ -27,6 +27,9 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import { Box } from '@mui/system';
 import humanizeDuration from 'humanize-duration';
@@ -291,17 +294,51 @@ const ScanPage: React.FC<Props> = () => {
       .finally(() => setNotebookLoading(false));
   };
 
+  let microscopePrefix = '';
+  if (microscope != null) {
+    const canonicalName = canonicalMicroscopeName(microscope.name);
+    microscopePrefix = `/${canonicalName}`;
+  }
+
   return (
     <React.Fragment>
-      <Button
-        onClick={onNavigateBack}
-        size="small"
-        color="primary"
-        sx={{ mb: 2 }}
-        variant="outlined"
-      >
-        {jobId ? `Session ${jobId}` : 'Scans'}
-      </Button>
+      <Breadcrumbs sx={{ mb: 2 }}>
+        {jobId && (
+          // Link to sessions
+          <Link
+            underline="hover"
+            color="inherit"
+            href={`${microscopePrefix}/sessions/`}
+          >
+            Sessions
+          </Link>
+        )}
+        {jobId && (
+          // Link to session
+          <Link
+            underline="hover"
+            color="inherit"
+            href={`${microscopePrefix}/sessions/`}
+          >
+            {jobId}
+          </Link>
+        )}
+        {/* Link to scans  */}
+        <Link
+          underline="hover"
+          color="inherit"
+          href={
+            jobId
+              ? `${microscopePrefix}/sessions/${jobId}`
+              : `${microscopePrefix}/scans`
+          }
+        >
+          Scans
+        </Link>
+
+        {/* The scan */}
+        <Typography color="text.primary">{scanId}</Typography>
+      </Breadcrumbs>
       <Card sx={{ marginBottom: '2rem' }}>
         <CardContent>
           <Grid container spacing={3}>

--- a/frontend/distiller/src/pages/session.tsx
+++ b/frontend/distiller/src/pages/session.tsx
@@ -1,6 +1,9 @@
 import LeftIcon from '@mui/icons-material/ArrowLeft';
 import RightIcon from '@mui/icons-material/ArrowRight';
 import { Button } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
 import React, { useEffect } from 'react';
 import { useNavigate, useParams as useUrlParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
@@ -66,6 +69,19 @@ const SessionPage: React.FC = () => {
           Next Session
         </Button>
       </div>
+      <Breadcrumbs>
+        {/* Link to sessions */}
+        <Link
+          underline="hover"
+          color="inherit"
+          href={`/${microscopeName}/sessions`}
+        >
+          Sessions
+        </Link>
+        {/* The session */}
+        {job && <Typography color="text.primary">{job.id}</Typography>}
+      </Breadcrumbs>
+
       {job && (
         <SessionCard jobId={job.id} isHoverable={false} compactMode={false} />
       )}


### PR DESCRIPTION
Fixes: #935

Here is an example of what a scan associated with a session:

<img width="1176" alt="Screenshot 2023-12-19 at 4 10 46 PM" src="https://github.com/OpenChemistry/distiller/assets/1031053/27488b7f-883f-40f7-bc9a-8f101d1ef890">
