### PR TITLE
Fix creating new user

### DIFF
--- a/backend/app/app/api/utils.py
+++ b/backend/app/app/api/utils.py
@@ -6,18 +6,18 @@ from app.core.constants import BLOCKSIZE
 
 
 # See https://github.com/fastapi/fastapi/discussions/11773#discussioncomment-10640267
-def verify_password(plain_password, hashed_password):
+def verify_password(plain_password: str, hashed_password: str):
     return bcrypt.checkpw(
         bytes(plain_password, encoding="utf-8"),
         bytes(hashed_password, encoding="utf-8"),
     )
 
 
-def get_password_hash(password):
+def get_password_hash(password: str) -> str:
     return bcrypt.hashpw(
         bytes(password, encoding="utf-8"),
         bcrypt.gensalt(),
-    )
+    ).decode()
 
 
 async def upload_to_file(upload: UploadFile, fp: AsyncBufferedIOBase):


### PR DESCRIPTION
To match old behavior for creating new users, we need to return a string with get_password_hash(). 

`bcrypt.hashpw()` returns bytes, we need to decode it on return.

Missed this before, my db was already initialized..