### PR TITLE
Allow for merging in query parameters

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/scans.py
+++ b/backend/app/app/api/api_v1/endpoints/scans.py
@@ -8,8 +8,16 @@ from typing import List, Optional, cast
 from urllib.parse import unquote
 
 import aiofiles
-from fastapi import (APIRouter, Depends, File, HTTPException, Response,
-                     UploadFile, status)
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+    status,
+)
 from fastapi.security.api_key import APIKey
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -273,7 +281,10 @@ def read_scan(response: Response, id: int, db: Session = Depends(get_db)):
     dependencies=[Depends(oauth2_password_bearer_or_api_key)],
 )
 async def update_scan(
-    id: int, payload: schemas.ScanUpdate, db: Session = Depends(get_db)
+    id: int,
+    payload: schemas.ScanUpdate,
+    merge: bool = Query(False),
+    db: Session = Depends(get_db),
 ):
     db_scan = crud.get_scan(db, id=id)
     if db_scan is None:
@@ -289,6 +300,7 @@ async def update_scan(
         notes=payload.notes,
         metadata=payload.metadata,
         job_id=payload.job_id,
+        merge=merge
     )
 
     if updated:

--- a/backend/app/app/crud/scan.py
+++ b/backend/app/app/crud/scan.py
@@ -175,8 +175,10 @@ def update_scan(
     notes: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
     job_id: Optional[int] = None,
+    merge: bool = False,
 ):
     updated = False
+    scan = None
 
     if progress is not None:
         statement = (
@@ -233,6 +235,14 @@ def update_scan(
         updated = updated or notes_updated
 
     if metadata is not None:
+        if merge:
+            scan = get_scan(db, id)
+            if scan is None:
+                raise Exception(f"Scan with id {id} does not exist.")
+            existing_metadata = scan.metadata_ or {}
+            if not isinstance(existing_metadata, dict):
+                existing_metadata = {}
+            metadata = {**existing_metadata, **metadata}
         statement = (
             update(models.Scan)
             .where(models.Scan.id == id)
@@ -247,7 +257,7 @@ def update_scan(
 
     if job_id is not None:
         jobs_updated = False
-        scan = get_scan(db, id)
+        scan = scan or get_scan(db, id)
         if scan is None:
             raise Exception(f"Scan with id {id} does not exist.")
         # If jobs get too large, this operation should be moved

--- a/frontend/distiller/src/features/scans/api.ts
+++ b/frontend/distiller/src/features/scans/api.ts
@@ -83,10 +83,20 @@ export function getScanJobs(id: IdType): Promise<Job[]> {
     .then((res) => res.json());
 }
 
-export function patchScan(id: IdType, updates: Partial<Scan>): Promise<Scan> {
+export function patchScan(
+  id: IdType,
+  updates: Partial<Scan>,
+  merge?: boolean,
+): Promise<Scan> {
+  const params: any = {};
+  if (!isNil(merge)) {
+    params['merge'] = merge;
+  }
+
   return apiClient
     .patch({
       path: `scans/${id}`,
+      params,
       json: updates,
     })
     .then((res) => res.json());

--- a/frontend/distiller/src/features/scans/index.ts
+++ b/frontend/distiller/src/features/scans/index.ts
@@ -93,10 +93,10 @@ export const getJobScans = createAsyncThunk<
 
 export const patchScan = createAsyncThunk<
   Scan,
-  { id: IdType; updates: Partial<Scan> }
+  { id: IdType; updates: Partial<Scan>; merge?: boolean }
 >('scans/patch', async (payload, _thunkAPI) => {
-  const { id, updates } = payload;
-  const scan = await patchScanAPI(id, updates);
+  const { id, updates, merge } = payload;
+  const scan = await patchScanAPI(id, updates, merge);
 
   return scan;
 });


### PR DESCRIPTION
Right now we do a simple replace for any params included in the patch scan operation. This introduces a query parameter `merge` that allows us to merge in new data. This is useful, for example, when merging in new metadata into a scan.