### PR TITLE
Ensure postgres URI is passed as str

### DIFF
--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -1,5 +1,5 @@
 import secrets
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from pydantic import AnyHttpUrl, PostgresDsn, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/backend/app/app/db/session.py
+++ b/backend/app/app/db/session.py
@@ -3,5 +3,5 @@ from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, pool_pre_ping=True)
+engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI), pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
In Pydantic v2, PostgresDsn is no longer a str subclass so we have to make the convertion explicit.