### PR TITLE
Add build-essentials

### DIFF
--- a/backend/faust/Dockerfile.notebook_worker
+++ b/backend/faust/Dockerfile.notebook_worker
@@ -5,13 +5,17 @@ WORKDIR /app
 
 COPY requirements.notebook.txt /app/requirements.txt
 
-RUN pip install -r /app/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install --no-cache-dir -r /app/requirements.txt \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY *.py /app/
 COPY *.env /app/
 COPY templates/ /app/templates/
 
-ENV WORKER notebook
+ENV WORKER=notebook
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/backend/faust/Dockerfile.worker
+++ b/backend/faust/Dockerfile.worker
@@ -4,11 +4,15 @@ FROM openchemistry/distiller-faust-base:latest
 WORKDIR /app
 
 ARG WORKER
-ENV WORKER $WORKER
+ENV WORKER=$WORKER
 
 COPY requirements.$WORKER.txt /app/requirements.txt
 
-RUN pip install -r /app/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install --no-cache-dir -r /app/requirements.txt \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY *.py /app/
 COPY *.env /app/


### PR DESCRIPTION
Some of the python packages need to be able to compile extensions.